### PR TITLE
Persist task board group and column updates

### DIFF
--- a/backend/src/main/java/com/mahindra/backend/controller/TaskBoardController.java
+++ b/backend/src/main/java/com/mahindra/backend/controller/TaskBoardController.java
@@ -1,5 +1,7 @@
 package com.mahindra.backend.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mahindra.backend.dto.taskboard.ColumnDefinitionDto;
+import com.mahindra.backend.dto.taskboard.ColumnUpdateRequest;
 import com.mahindra.backend.dto.taskboard.ColumnUpsertRequest;
 import com.mahindra.backend.dto.taskboard.CreateGroupRequest;
 import com.mahindra.backend.dto.taskboard.CreateTaskRequest;
@@ -25,6 +28,7 @@ import com.mahindra.backend.dto.taskboard.TaskDto;
 import com.mahindra.backend.dto.taskboard.TaskGroupDto;
 import com.mahindra.backend.dto.taskboard.TaskPatchRequest;
 import com.mahindra.backend.dto.taskboard.TaskUpdateDto;
+import com.mahindra.backend.dto.taskboard.UpdateGroupRequest;
 import com.mahindra.backend.service.TaskBoardService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -56,6 +60,15 @@ public class TaskBoardController {
             @Valid @RequestBody CreateGroupRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(taskBoardService.createGroup(authentication, workspaceId, boardId, request));
+    }
+
+    @PatchMapping("/groups/{groupId}")
+    public ResponseEntity<TaskGroupDto> updateGroup(Authentication authentication,
+            @PathVariable Long workspaceId,
+            @PathVariable Long boardId,
+            @PathVariable Long groupId,
+            @RequestBody UpdateGroupRequest request) {
+        return ResponseEntity.ok(taskBoardService.updateGroup(authentication, workspaceId, boardId, groupId, request));
     }
 
     @PostMapping("/groups/{groupId}/tasks")
@@ -93,6 +106,14 @@ public class TaskBoardController {
             @Valid @RequestBody ColumnUpsertRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(taskBoardService.createColumn(authentication, workspaceId, boardId, request));
+    }
+
+    @PutMapping("/columns")
+    public ResponseEntity<List<ColumnDefinitionDto>> replaceColumns(Authentication authentication,
+            @PathVariable Long workspaceId,
+            @PathVariable Long boardId,
+            @RequestBody List<ColumnUpdateRequest> request) {
+        return ResponseEntity.ok(taskBoardService.replaceColumns(authentication, workspaceId, boardId, request));
     }
 
     @PostMapping("/tasks/{taskId}/updates")

--- a/backend/src/main/java/com/mahindra/backend/dto/taskboard/ColumnUpdateRequest.java
+++ b/backend/src/main/java/com/mahindra/backend/dto/taskboard/ColumnUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.mahindra.backend.dto.taskboard;
+
+import java.util.List;
+
+public record ColumnUpdateRequest(
+        String id,
+        String label,
+        String type,
+        Integer width,
+        Boolean visible,
+        Integer order,
+        List<SelectOptionDto> options) {
+}

--- a/backend/src/main/java/com/mahindra/backend/dto/taskboard/UpdateGroupRequest.java
+++ b/backend/src/main/java/com/mahindra/backend/dto/taskboard/UpdateGroupRequest.java
@@ -1,0 +1,7 @@
+package com.mahindra.backend.dto.taskboard;
+
+public record UpdateGroupRequest(
+        String name,
+        String color,
+        Integer order) {
+}

--- a/backend/src/main/java/com/mahindra/backend/service/TaskBoardService.java
+++ b/backend/src/main/java/com/mahindra/backend/service/TaskBoardService.java
@@ -23,6 +23,7 @@ import com.mahindra.backend.dto.taskboard.BoardConfigDto;
 import com.mahindra.backend.dto.taskboard.BoardSummaryDto;
 import com.mahindra.backend.dto.taskboard.BoardViewDto;
 import com.mahindra.backend.dto.taskboard.ColumnDefinitionDto;
+import com.mahindra.backend.dto.taskboard.ColumnUpdateRequest;
 import com.mahindra.backend.dto.taskboard.ColumnUpsertRequest;
 import com.mahindra.backend.dto.taskboard.CreateGroupRequest;
 import com.mahindra.backend.dto.taskboard.CreateTaskRequest;
@@ -36,6 +37,7 @@ import com.mahindra.backend.dto.taskboard.TaskDto;
 import com.mahindra.backend.dto.taskboard.TaskGroupDto;
 import com.mahindra.backend.dto.taskboard.TaskPatchRequest;
 import com.mahindra.backend.dto.taskboard.TaskUpdateDto;
+import com.mahindra.backend.dto.taskboard.UpdateGroupRequest;
 import com.mahindra.backend.dto.taskboard.UserSummaryDto;
 import com.mahindra.backend.entity.Board;
 import com.mahindra.backend.entity.BoardColumn;
@@ -143,6 +145,38 @@ public class TaskBoardService {
         taskGroupRepository.save(group);
         recordActivity(board, null, user, "group_created", "group", null, group.getName(), "user");
         return toGroupDto(group, List.of());
+    }
+
+    @Transactional
+    public TaskGroupDto updateGroup(Authentication authentication, Long workspaceId, Long boardId, Long groupId,
+            UpdateGroupRequest request) {
+        User user = resolveUser(authentication);
+        Board board = resolveEditableBoard(user, workspaceId, boardId);
+        TaskGroup group = taskGroupRepository.findById(groupId)
+                .filter(g -> g.getDeletedAt() == null && g.getBoard().getId().equals(boardId))
+                .orElseThrow(() -> new ResourceNotFoundException("Task group not found"));
+        Map<String, Object> before = new LinkedHashMap<>();
+        before.put("name", group.getName());
+        before.put("color", group.getColor());
+        before.put("order", group.getPosition());
+
+        if (request.name() != null && !request.name().isBlank()) {
+            group.setName(request.name().trim());
+        }
+        if (request.color() != null && !request.color().isBlank()) {
+            group.setColor(request.color());
+        }
+        if (request.order() != null) {
+            group.setPosition(Math.max(0, request.order()));
+        }
+        group.setUpdatedAt(Instant.now());
+        taskGroupRepository.save(group);
+        Map<String, Object> after = new LinkedHashMap<>();
+        after.put("name", group.getName());
+        after.put("color", group.getColor());
+        after.put("order", group.getPosition());
+        recordActivity(board, null, user, "group_updated", "group", before, after, "user");
+        return toGroupDto(group, taskRepository.findByGroupIdAndDeletedAtIsNullOrderByPositionAscIdAsc(groupId));
     }
 
     @Transactional
@@ -262,6 +296,60 @@ public class TaskBoardService {
     }
 
     @Transactional
+    public List<ColumnDefinitionDto> replaceColumns(Authentication authentication, Long workspaceId, Long boardId,
+            List<ColumnUpdateRequest> request) {
+        User user = resolveUser(authentication);
+        Board board = resolveEditableBoard(user, workspaceId, boardId);
+        List<BoardColumn> existingColumns = boardColumnRepository.findByBoardIdAndDeletedAtIsNullOrderByPositionAscIdAsc(boardId);
+        Map<String, BoardColumn> existingByKey = existingColumns.stream()
+                .collect(Collectors.toMap(BoardColumn::getKey, Function.identity()));
+        Set<String> requestedKeys = request.stream()
+                .map(ColumnUpdateRequest::id)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        int index = 0;
+        for (ColumnUpdateRequest input : request) {
+            if (input.id() == null || input.id().isBlank()) {
+                continue;
+            }
+            BoardColumn column = existingByKey.get(input.id());
+            if (column == null) {
+                column = new BoardColumn();
+                column.setBoard(board);
+                column.setKey(input.id());
+                column.setSystemColumn(false);
+                existingByKey.put(input.id(), column);
+            }
+            if (input.label() != null && !input.label().isBlank()) {
+                column.setLabel(input.label().trim());
+            }
+            if (input.type() != null && !input.type().isBlank()) {
+                column.setType(input.type());
+            }
+            column.setWidth(input.width());
+            column.setVisible(input.visible() == null || input.visible());
+            column.setPosition(input.order() != null ? input.order() : index);
+            column.setUpdatedAt(Instant.now());
+            applyColumnOptions(column, input.options(), user);
+            boardColumnRepository.save(column);
+            index++;
+        }
+
+        for (BoardColumn column : existingColumns) {
+            if (!Boolean.TRUE.equals(column.getSystemColumn()) && !requestedKeys.contains(column.getKey())) {
+                column.setDeletedAt(Instant.now());
+                column.setDeletedBy(user);
+                column.setPurgeAfter(Instant.now().plusSeconds(30L * 24 * 60 * 60));
+                boardColumnRepository.save(column);
+            }
+        }
+        recordActivity(board, null, user, "columns_updated", "columns", null, request, "user");
+        return boardColumnRepository.findByBoardIdAndDeletedAtIsNullOrderByPositionAscIdAsc(boardId)
+                .stream().map(this::toColumnDto).toList();
+    }
+
+    @Transactional
     public TaskUpdateDto createUpdate(Authentication authentication, Long workspaceId, Long boardId, Long taskId,
             CreateUpdateRequest request) {
         User user = resolveUser(authentication);
@@ -309,16 +397,20 @@ public class TaskBoardService {
         TaskGroup targetGroup = taskGroupRepository.findById(request.toGroupId())
                 .filter(g -> g.getBoard().getId().equals(targetBoard.getId()) && g.getDeletedAt() == null)
                 .orElseThrow(() -> new ResourceNotFoundException("Target group not found"));
+        Long sourceGroupId = task.getGroup() != null ? task.getGroup().getId() : null;
 
         if (!sourceBoard.getId().equals(targetBoard.getId())) {
             discardIncompatibleCustomValues(task, targetBoard, user);
         }
         task.setBoard(targetBoard);
         task.setGroup(targetGroup);
-        task.setPosition(request.position() != null ? request.position()
-                : taskRepository.findByGroupIdAndDeletedAtIsNullOrderByPositionAscIdAsc(targetGroup.getId()).size());
+        task.setPosition(0);
         task.setUpdatedAt(Instant.now());
         taskRepository.save(task);
+        if (sourceGroupId != null && !sourceGroupId.equals(targetGroup.getId())) {
+            normalizeTaskPositions(sourceGroupId, null, null);
+        }
+        normalizeTaskPositions(targetGroup.getId(), task, request.position());
         recordActivity(targetBoard, task, user, "task_moved", "board", sourceBoard.getId(), targetBoard.getId(), "user");
     }
 
@@ -428,6 +520,41 @@ public class TaskBoardService {
         return option;
     }
 
+    private void applyColumnOptions(BoardColumn column, List<SelectOptionDto> options, User user) {
+        if (options == null) {
+            return;
+        }
+        Map<String, BoardColumnOption> existingByKey = column.getOptions().stream()
+                .collect(Collectors.toMap(BoardColumnOption::getKey, Function.identity(), (a, b) -> a));
+        Set<String> requestedKeys = options.stream().map(SelectOptionDto::id).collect(Collectors.toSet());
+        int index = 0;
+        for (SelectOptionDto input : options) {
+            if (input.id() == null || input.id().isBlank()) {
+                continue;
+            }
+            BoardColumnOption option = existingByKey.get(input.id());
+            if (option == null) {
+                option = option(input.id(), input.label(), input.color(), index);
+                column.addOption(option);
+            } else {
+                option.setLabel(input.label());
+                option.setColor(input.color());
+                option.setPosition(index);
+                option.setDeletedAt(null);
+                option.setDeletedBy(null);
+                option.setPurgeAfter(null);
+            }
+            index++;
+        }
+        for (BoardColumnOption option : column.getOptions()) {
+            if (!requestedKeys.contains(option.getKey())) {
+                option.setDeletedAt(Instant.now());
+                option.setDeletedBy(user);
+                option.setPurgeAfter(Instant.now().plusSeconds(30L * 24 * 60 * 60));
+            }
+        }
+    }
+
     private BoardView view(Board board, String name, String type, int position, boolean isDefault, User actor) {
         BoardView view = new BoardView();
         view.setBoard(board);
@@ -531,6 +658,20 @@ public class TaskBoardService {
             task.getCustomValues().removeAll(discarded);
             recordActivity(targetBoard, task, user, "custom_values_discarded", "custom_values", oldValues, null, "internal");
         }
+    }
+
+    private void normalizeTaskPositions(Long groupId, Task insertedTask, Integer requestedPosition) {
+        List<Task> orderedTasks = new ArrayList<>(taskRepository.findByGroupIdAndDeletedAtIsNullOrderByPositionAscIdAsc(groupId));
+        if (insertedTask != null) {
+            orderedTasks.removeIf(t -> t.getId().equals(insertedTask.getId()));
+            int position = requestedPosition == null ? orderedTasks.size()
+                    : Math.max(0, Math.min(requestedPosition, orderedTasks.size()));
+            orderedTasks.add(position, insertedTask);
+        }
+        for (int i = 0; i < orderedTasks.size(); i++) {
+            orderedTasks.get(i).setPosition(i);
+        }
+        taskRepository.saveAll(orderedTasks);
     }
 
     private Map<String, BoardColumnOption> optionMap(Long boardId, String columnKey) {

--- a/frontend/src/components/workspaces/taskboard/TaskBoardContext.tsx
+++ b/frontend/src/components/workspaces/taskboard/TaskBoardContext.tsx
@@ -27,8 +27,11 @@ import {
   createTaskUpdate,
   deleteTask as deleteTaskRequest,
   getTaskBoard,
+  moveTask as moveTaskRequest,
   patchTask,
+  replaceColumns,
   type BoardMoveTarget,
+  updateTaskGroup,
 } from '../../../services/taskBoardService';
 
 // ─── localStorage helpers (Section 18 of spec) ───
@@ -444,15 +447,8 @@ export function TaskBoardProvider({ workspaceId, boardId, children }: TaskBoardP
       updatedAt: new Date().toISOString(),
     };
 
-    const updatedTasks = { ...tasks, [newTaskId]: newTask };
-    const updatedGroups = groups.map((g) =>
-      g.id === targetGroup.id ? { ...g, taskIds: [...g.taskIds, newTaskId] } : g
-    );
-
-    setTasks(updatedTasks);
-    setGroups(updatedGroups);
-    syncStorage(boardConfig, updatedGroups, updatedTasks, manualGroupOrder);
-  }, [visibleGroups, boardId, boardConfig, tasks, groups, manualGroupOrder, syncStorage]);
+    addTask(newTask);
+  }, [visibleGroups, boardId, boardConfig, addTask]);
 
   // Insert an empty group in the second position of the board
   const addGroupAtSecondPosition = useCallback(() => {
@@ -513,8 +509,13 @@ export function TaskBoardProvider({ workspaceId, boardId, children }: TaskBoardP
       setGroups(updatedGroups);
       setTasks(updatedTasks);
       syncStorage(boardConfig, updatedGroups, updatedTasks, manualGroupOrder);
+      void moveTaskRequest(workspaceId, boardId, taskId, {
+        toBoardId: boardId,
+        toGroupId,
+        position: newIndex,
+      }).catch((e) => setError(e instanceof Error ? e.message : 'Failed to move task'));
     },
-    [groups, tasks, boardConfig, manualGroupOrder, syncStorage]
+    [workspaceId, boardId, groups, tasks, boardConfig, manualGroupOrder, syncStorage]
   );
 
   const moveTaskToGroup = useCallback(
@@ -544,8 +545,13 @@ export function TaskBoardProvider({ workspaceId, boardId, children }: TaskBoardP
       setGroups(updatedGroups);
       setTasks(updatedTasks);
       syncStorage(boardConfig, updatedGroups, updatedTasks, manualGroupOrder);
+      void moveTaskRequest(workspaceId, boardId, taskId, {
+        toBoardId: boardId,
+        toGroupId,
+        position: groups.find((g) => g.id === toGroupId)?.taskIds.length ?? 0,
+      }).catch((e) => setError(e instanceof Error ? e.message : 'Failed to move task'));
     },
-    [tasks, groups, boardConfig, manualGroupOrder, syncStorage]
+    [workspaceId, boardId, tasks, groups, boardConfig, manualGroupOrder, syncStorage]
   );
 
   const moveTaskToBoardGroup = useCallback(
@@ -600,8 +606,13 @@ export function TaskBoardProvider({ workspaceId, boardId, children }: TaskBoardP
         manualGroupOrder: targetState.manualGroupOrder,
       });
       syncStorage(boardConfig, updatedCurrentGroups, updatedCurrentTasks, manualGroupOrder);
+      void moveTaskRequest(workspaceId, boardId, taskId, {
+        toBoardId,
+        toGroupId,
+        position: targetState.groups.find((g) => g.id === toGroupId)?.taskIds.length ?? 0,
+      }).catch((e) => setError(e instanceof Error ? e.message : 'Failed to move task'));
     },
-    [boardId, moveTaskToGroup, tasks, groups, boardConfig, manualGroupOrder, syncStorage]
+    [workspaceId, boardId, moveTaskToGroup, tasks, groups, boardConfig, manualGroupOrder, syncStorage]
   );
 
   const toggleTaskComplete = useCallback((taskId: string) => {
@@ -643,8 +654,13 @@ export function TaskBoardProvider({ workspaceId, boardId, children }: TaskBoardP
       const updatedConfig = { ...boardConfig, columns };
       setBoardConfig(updatedConfig);
       syncStorage(updatedConfig, groups, tasks, manualGroupOrder);
+      void replaceColumns(workspaceId, boardId, columns)
+        .then((savedColumns) => {
+          setBoardConfig((prev) => ({ ...prev, columns: savedColumns }));
+        })
+        .catch((e) => setError(e instanceof Error ? e.message : 'Failed to update columns'));
     },
-    [boardConfig, groups, tasks, manualGroupOrder, syncStorage]
+    [workspaceId, boardId, boardConfig, groups, tasks, manualGroupOrder, syncStorage]
   );
 
   const addColumn = useCallback(
@@ -670,8 +686,12 @@ export function TaskBoardProvider({ workspaceId, boardId, children }: TaskBoardP
       const updatedOrder = newGroups.map((g) => g.id);
       setManualGroupOrder(updatedOrder);
       syncStorage(boardConfig, groups, tasks, updatedOrder);
+      newGroups.forEach((group, index) => {
+        void updateTaskGroup(workspaceId, boardId, group.id, { order: index })
+          .catch((e) => setError(e instanceof Error ? e.message : 'Failed to reorder groups'));
+      });
     },
-    [boardConfig, groups, tasks, syncStorage]
+    [workspaceId, boardId, boardConfig, groups, tasks, syncStorage]
   );
 
   const updateGroupColor = useCallback(
@@ -681,8 +701,10 @@ export function TaskBoardProvider({ workspaceId, boardId, children }: TaskBoardP
       );
       setGroups(updatedGroups);
       syncStorage(boardConfig, updatedGroups, tasks, manualGroupOrder);
+      void updateTaskGroup(workspaceId, boardId, groupId, { color })
+        .catch((e) => setError(e instanceof Error ? e.message : 'Failed to update group'));
     },
-    [groups, boardConfig, tasks, manualGroupOrder, syncStorage]
+    [workspaceId, boardId, groups, boardConfig, tasks, manualGroupOrder, syncStorage]
   );
 
   const updateGroupName = useCallback(
@@ -692,8 +714,10 @@ export function TaskBoardProvider({ workspaceId, boardId, children }: TaskBoardP
       );
       setGroups(updatedGroups);
       syncStorage(boardConfig, updatedGroups, tasks, manualGroupOrder);
+      void updateTaskGroup(workspaceId, boardId, groupId, { name })
+        .catch((e) => setError(e instanceof Error ? e.message : 'Failed to update group'));
     },
-    [groups, boardConfig, tasks, manualGroupOrder, syncStorage]
+    [workspaceId, boardId, groups, boardConfig, tasks, manualGroupOrder, syncStorage]
   );
 
   const moveGroupToBoard = useCallback(
@@ -803,20 +827,36 @@ export function TaskBoardProvider({ workspaceId, boardId, children }: TaskBoardP
 
   const updateStatusOptions = useCallback(
     (statusOptions: SelectOption[]) => {
-      const updatedConfig = { ...boardConfig, statusOptions };
+      const columns = boardConfig.columns.map((column) => (
+        column.id === 'col_status' ? { ...column, options: statusOptions } : column
+      ));
+      const updatedConfig = { ...boardConfig, columns, statusOptions };
       setBoardConfig(updatedConfig);
       syncStorage(updatedConfig, groups, tasks, manualGroupOrder);
+      void replaceColumns(workspaceId, boardId, columns)
+        .then((savedColumns) => {
+          setBoardConfig((prev) => ({ ...prev, columns: savedColumns }));
+        })
+        .catch((e) => setError(e instanceof Error ? e.message : 'Failed to update status options'));
     },
-    [boardConfig, groups, tasks, manualGroupOrder, syncStorage]
+    [workspaceId, boardId, boardConfig, groups, tasks, manualGroupOrder, syncStorage]
   );
 
   const updatePriorityOptions = useCallback(
     (priorityOptions: SelectOption[]) => {
-      const updatedConfig = { ...boardConfig, priorityOptions };
+      const columns = boardConfig.columns.map((column) => (
+        column.id === 'col_priority' ? { ...column, options: priorityOptions } : column
+      ));
+      const updatedConfig = { ...boardConfig, columns, priorityOptions };
       setBoardConfig(updatedConfig);
       syncStorage(updatedConfig, groups, tasks, manualGroupOrder);
+      void replaceColumns(workspaceId, boardId, columns)
+        .then((savedColumns) => {
+          setBoardConfig((prev) => ({ ...prev, columns: savedColumns }));
+        })
+        .catch((e) => setError(e instanceof Error ? e.message : 'Failed to update priority options'));
     },
-    [boardConfig, groups, tasks, manualGroupOrder, syncStorage]
+    [workspaceId, boardId, boardConfig, groups, tasks, manualGroupOrder, syncStorage]
   );
 
   // ─── Memoized Context Value ───

--- a/frontend/src/components/workspaces/taskboard/table/MainTableView.tsx
+++ b/frontend/src/components/workspaces/taskboard/table/MainTableView.tsx
@@ -77,6 +77,14 @@ export default function MainTableView() {
         const newIndex = toGroup.taskIds.indexOf(overTaskItem.id);
         moveTask(activeTaskItem.id, fromGroup.id, toGroup.id, newIndex);
       }
+    } else if (activeData?.type === 'Task' && overData?.type === 'Group') {
+      const activeTaskItem = activeData.task as Task;
+      const overGroupItem = overData.group as TaskGroupType;
+
+      const fromGroup = visibleGroups.find((g) => g.taskIds.includes(activeTaskItem.id));
+      if (fromGroup && fromGroup.id !== overGroupItem.id) {
+        moveTask(activeTaskItem.id, fromGroup.id, overGroupItem.id, overGroupItem.taskIds.length);
+      }
     } else if (activeData?.type === 'Group' && overData?.type === 'Group') {
       const activeGroupItem = activeData.group as TaskGroupType;
       const overGroupItem = overData.group as TaskGroupType;

--- a/frontend/src/services/taskBoardService.ts
+++ b/frontend/src/services/taskBoardService.ts
@@ -74,6 +74,23 @@ export async function createTaskGroup(
   }
 }
 
+export async function updateTaskGroup(
+  workspaceId: string,
+  boardId: string,
+  groupId: string,
+  payload: { name?: string; color?: string; order?: number }
+): Promise<TaskGroup> {
+  try {
+    const { data } = await apiClient.patch<TaskGroup>(
+      `/api/workspaces/${workspaceId}/boards/${boardId}/groups/${groupId}`,
+      payload
+    );
+    return data;
+  } catch (e) {
+    throw new Error(getErrorMessage(e));
+  }
+}
+
 export async function createTask(
   workspaceId: string,
   boardId: string,
@@ -113,6 +130,23 @@ export async function deleteTask(workspaceId: string, boardId: string, taskId: s
   }
 }
 
+export async function moveTask(
+  workspaceId: string,
+  boardId: string,
+  taskId: string,
+  payload: { toBoardId: string; toGroupId: string; position?: number }
+): Promise<void> {
+  try {
+    await apiClient.put(`/api/workspaces/${workspaceId}/boards/${boardId}/tasks/${taskId}/move`, {
+      toBoardId: Number(payload.toBoardId),
+      toGroupId: Number(payload.toGroupId),
+      position: payload.position,
+    });
+  } catch (e) {
+    throw new Error(getErrorMessage(e));
+  }
+}
+
 export async function createColumn(
   workspaceId: string,
   boardId: string,
@@ -127,6 +161,27 @@ export async function createColumn(
       order: column.order,
       options: column.options ?? [],
     });
+    return data;
+  } catch (e) {
+    throw new Error(getErrorMessage(e));
+  }
+}
+
+export async function replaceColumns(
+  workspaceId: string,
+  boardId: string,
+  columns: ColumnDefinition[]
+): Promise<ColumnDefinition[]> {
+  try {
+    const { data } = await apiClient.put<ColumnDefinition[]>(`/api/workspaces/${workspaceId}/boards/${boardId}/columns`, columns.map((column) => ({
+      id: column.id,
+      label: column.label,
+      type: column.type,
+      width: column.width,
+      visible: column.isVisible,
+      order: column.order,
+      options: column.options ?? [],
+    })));
     return data;
   } catch (e) {
     throw new Error(getErrorMessage(e));


### PR DESCRIPTION
## Summary
- Persist task group name, color, and ordering changes through backend endpoints
- Persist column ordering and select/status/priority option updates
- Persist task moves across groups and allow dropping tasks into empty groups

## Validation
- npm run lint
- npm run build
- mvn -q test